### PR TITLE
Provide binary download of libRmath-julia dll on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,39 @@
+environment:
+  matrix:
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+
+branches:
+  only:
+    - master
+    - /release-.*/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+# If there's a newer build queued for the same PR, cancel this one
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
+# Download most recent Julia Windows binary
+  - ps: (new-object net.webclient).DownloadFile(
+        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
+        "C:\projects\julia-binary.exe")
+# Run installer silently, output to C:\projects\julia
+  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+
+build_script:
+# Need to convert from shallow to complete for Pkg.clone to work
+  - IF EXIST .git\shallow (git fetch --unshallow)
+  - C:\projects\julia\bin\julia -e "versioninfo();
+      Pkg.clone(pwd(), \"Rmath\"); Pkg.build(\"Rmath\")"
+
+test_script:
+  - C:\projects\julia\bin\julia -e "Pkg.test(\"Rmath\")"

--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -2,3 +2,6 @@ downloads
 src
 usr
 deps.jl
+bin32
+bin64
+COPYING

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -13,6 +13,15 @@ provides(Sources, URI("https://github.com/JuliaLang/Rmath-julia/archive/v$versio
 prefix = joinpath(BinDeps.depsdir(libRmath), "usr")
 srcdir = joinpath(BinDeps.srcdir(libRmath), "Rmath-julia-$version")
 
+# These Windows binaries were taken from `make -C deps install-Rmath-julia`
+# in a Cygwin cross-compile from the release-0.4 branch of julia
+# Future work: standalone cross-compiled binaries using openSUSE docker container
+provides(Binaries,
+    URI("https://dl.bintray.com/tkelman/generic/libRmath-julia.7z"),
+    [libRmath], unpacked_dir="bin$(Sys.WORD_SIZE)",
+    SHA="d70db19ce7c1aa11015ff9e25e08d068bb80d1237570c9d60ece372712dd3754",
+    os = :Windows)
+
 # If your library uses configure or cmake, good idea to do an
 # out-of-tree build - see examples in JuliaOpt and JuliaWeb
 provides(SimpleBuild,

--- a/src/Rmath.jl
+++ b/src/Rmath.jl
@@ -2,6 +2,8 @@
 ## This module is for archival purposes.  The interface in the
 ## Distributions module is much more effective.
 
+__precompile__()
+
 module Rmath
 
 using Compat


### PR DESCRIPTION
This is the quick-and-dirty solution to close https://github.com/JuliaLang/julia/issues/17438 and fix #7, just uploading the dll as-is from a build of release-0.4 Julia. Who has the least-busy appveyor account and wants to enable this package there?

Also enabling precompilation.