### PR TITLE
rename libRmath to be libRmathjulia

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,23 +2,23 @@ using BinDeps
 
 @BinDeps.setup
 
-libRmath = library_dependency("libRmath", aliases=["libRmath-julia"])
+libRmathdep = library_dependency("libRmathjulia", aliases=["libRmath-julia"])
 version = "0.1"
 # Best practice to use a fixed version here, either a version number tag or a git sha
 # Please don't download "latest master" because the version that works today might not work tomorrow
 
 provides(Sources, URI("https://github.com/JuliaLang/Rmath-julia/archive/v$version.tar.gz"),
-    [libRmath], unpacked_dir="Rmath-julia-$version")
+    [libRmathdep], unpacked_dir="Rmath-julia-$version")
 
-prefix = joinpath(BinDeps.depsdir(libRmath), "usr")
-srcdir = joinpath(BinDeps.srcdir(libRmath), "Rmath-julia-$version")
+prefix = joinpath(BinDeps.depsdir(libRmathdep), "usr")
+srcdir = joinpath(BinDeps.srcdir(libRmathdep), "Rmath-julia-$version")
 
 # These Windows binaries were taken from `make -C deps install-Rmath-julia`
 # in a Cygwin cross-compile from the release-0.4 branch of julia
 # Future work: standalone cross-compiled binaries using openSUSE docker container
 provides(Binaries,
     URI("https://dl.bintray.com/tkelman/generic/libRmath-julia.7z"),
-    [libRmath], unpacked_dir="bin$(Sys.WORD_SIZE)",
+    [libRmathdep], unpacked_dir="bin$(Sys.WORD_SIZE)",
     SHA="d70db19ce7c1aa11015ff9e25e08d068bb80d1237570c9d60ece372712dd3754",
     os = :Windows)
 
@@ -26,13 +26,13 @@ provides(Binaries,
 # out-of-tree build - see examples in JuliaOpt and JuliaWeb
 provides(SimpleBuild,
     (@build_steps begin
-        GetSources(libRmath)
+        GetSources(libRmathdep)
         CreateDirectory(joinpath(prefix, "lib"))
         @build_steps begin
             ChangeDirectory(srcdir)
             `make`
             `mv src/libRmath-julia.$(Libdl.dlext) $prefix/lib`
         end
-    end), [libRmath], os = :Unix)
+    end), [libRmathdep], os = :Unix)
 
-@BinDeps.install Dict(:libRmath => :libRmath)
+@BinDeps.install Dict(:libRmathjulia => :libRmathjulia)

--- a/src/Rmath.jl
+++ b/src/Rmath.jl
@@ -191,7 +191,7 @@ end
                 global $func
                 function $libcall(x::Vector)
                     gc_tracking_obj = []
-                    ccall(($(string(libcall)),libRmath), Void, ())
+                    ccall(($(string(libcall)),libRmathjulia), Void, ())
                 end
                 function $func()
                     if !isa(gc_tracking_obj, Bool)
@@ -238,16 +238,16 @@ end
         quote
             global $dd, $pp, $qq, $rr
             $dd(x::Number, p1::Number, give_log::Bool) = 
-                ccall(($(string(dd)),libRmath), Float64,
+                ccall(($(string(dd)),libRmathjulia), Float64,
                       (Float64,Float64,Int32), x, p1, give_log)
             $pp(q::Number, p1::Number, lower_tail::Bool, log_p::Bool) =
-                ccall(($(string(pp)),libRmath), Float64,
+                ccall(($(string(pp)),libRmathjulia), Float64,
                       (Float64,Float64,Int32,Int32), q, p1, lower_tail, log_p)
             $qq(p::Number, p1::Number, lower_tail::Bool, log_p::Bool) =
-                ccall(($(string(qq)),libRmath), Float64,
+                ccall(($(string(qq)),libRmathjulia), Float64,
                       (Float64,Float64,Int32,Int32), p, p1, lower_tail, log_p)
             $rr(nn::Integer, p1::Number) =
-                [ccall(($(string(rr)),libRmath), Float64, (Float64,), p1) for i=1:nn]
+                [ccall(($(string(rr)),libRmathjulia), Float64, (Float64,), p1) for i=1:nn]
             @libRmath_1par_0d_aliases $base
         end
     end
@@ -262,19 +262,19 @@ end
     @libRmath_deferred_free signrank
     function dsignrank(x::Number, p1::Number, give_log::Bool)
         signrank_deferred_free()
-        ccall((:dsignrank,libRmath), Float64, (Float64,Float64,Int32), x, p1, give_log)
+        ccall((:dsignrank,libRmathjulia), Float64, (Float64,Float64,Int32), x, p1, give_log)
     end
     function psignrank(q::Number, p1::Number, lower_tail::Bool, log_p::Bool)
         signrank_deferred_free()
-        ccall((:psignrank,libRmath), Float64, (Float64,Float64,Int32,Int32), q, p1, lower_tail, log_p)
+        ccall((:psignrank,libRmathjulia), Float64, (Float64,Float64,Int32,Int32), q, p1, lower_tail, log_p)
     end
     function qsignrank(p::Number, p1::Number, lower_tail::Bool, log_p::Bool)
         signrank_deferred_free()
-        ccall((:qsignrank,libRmath), Float64, (Float64,Float64,Int32,Int32), p, p1, lower_tail, log_p)
+        ccall((:qsignrank,libRmathjulia), Float64, (Float64,Float64,Int32,Int32), p, p1, lower_tail, log_p)
     end
     @libRmath_1par_0d_aliases signrank
     rsignrank(nn::Integer, p1::Number) =
-        [ccall((:rsignrank,libRmath), Float64, (Float64,), p1) for i=1:nn]
+        [ccall((:rsignrank,libRmathjulia), Float64, (Float64,), p1) for i=1:nn]
 
     ## Distributions with 1 parameter and a default
     macro libRmath_1par_1d(base, d1)
@@ -285,7 +285,7 @@ end
         quote
             global $dd, $pp, $qq, $rr
             $dd(x::Number, p1::Number, give_log::Bool) = 
-                ccall(($(string(dd)),libRmath), Float64, (Float64,Float64,Int32), x, p1, give_log)
+                ccall(($(string(dd)),libRmathjulia), Float64, (Float64,Float64,Int32), x, p1, give_log)
             $dd{T<:Number}(x::AbstractArray{T}, p1::Number, give_log::Bool) =
                 reshape([$dd(x[i], p1, give_log) for i=1:length(x)], size(x))
         $dd(x::Number, give_log::Bool) = $dd(x, $d1, give_log)
@@ -296,7 +296,7 @@ end
         $dd{T<:Number}(x::AbstractArray{T}) = $dd(x, $d1, false)
 
         $pp(q::Number, p1::Number, lower_tail::Bool, log_p::Bool) =
-            ccall(($(string(pp)),libRmath), Float64, (Float64,Float64,Int32,Int32), q, p1, lower_tail, log_p)
+            ccall(($(string(pp)),libRmathjulia), Float64, (Float64,Float64,Int32,Int32), q, p1, lower_tail, log_p)
         $pp{T<:Number}(q::AbstractArray{T}, p1::Number, lower_tail::Bool, log_p::Bool) =
             reshape([$pp(q[i], p1, lower_tail, log_p) for i=1:length(q)], size(q))
         $pp(q::Number, lower_tail::Bool, log_p::Bool) = $pp(q, $d1, lower_tail, log_p)
@@ -311,7 +311,7 @@ end
         $pp{T<:Number}(q::AbstractArray{T}) = $pp(q, $d1, true, false)
 
         $qq(p::Number, p1::Number, lower_tail::Bool, log_p::Bool) =
-            ccall(($(string(qq)),libRmath), Float64, (Float64,Float64,Int32,Int32), p, p1, lower_tail, log_p)
+            ccall(($(string(qq)),libRmathjulia), Float64, (Float64,Float64,Int32,Int32), p, p1, lower_tail, log_p)
         $qq{T<:Number}(p::AbstractArray{T}, p1::Number, lower_tail::Bool, log_p::Bool) =
             reshape([$qq(p[i], p1, lower_tail, log_p) for i=1:length(p)], size(p))
         $qq(p::Number, lower_tail::Bool, log_p::Bool) = $qq(p, $d1, lower_tail, log_p)
@@ -326,7 +326,7 @@ end
         $qq{T<:Number}(p::AbstractArray{T}) = $qq(p, $d1, true, false)
 
         $rr(nn::Integer, p1::Number) =
-            [ccall(($(string(rr)),libRmath), Float64, (Float64,), p1) for i=1:nn]
+            [ccall(($(string(rr)),libRmathjulia), Float64, (Float64,), p1) for i=1:nn]
         $rr(nn::Integer) = $rr(nn, $d1)
     end
 end
@@ -373,13 +373,13 @@ macro libRmath_2par_0d(base)
     quote
         global $dd, $pp, $qq, $rr
         $dd(x::Number, p1::Number, p2::Number, give_log::Bool) =
-            ccall(($(string(dd)),libRmath), Float64, (Float64,Float64,Float64,Int32), x, p1, p2, give_log)
+            ccall(($(string(dd)),libRmathjulia), Float64, (Float64,Float64,Float64,Int32), x, p1, p2, give_log)
         $pp(q::Number, p1::Number, p2::Number, lower_tail::Bool, log_p::Bool) =
-            ccall(($(string(pp)),libRmath), Float64, (Float64,Float64,Float64,Int32,Int32), q, p1, p2, lower_tail, log_p)
+            ccall(($(string(pp)),libRmathjulia), Float64, (Float64,Float64,Float64,Int32,Int32), q, p1, p2, lower_tail, log_p)
         $qq(p::Number, p1::Number, p2::Number, lower_tail::Bool, log_p::Bool) =
-            ccall(($(string(qq)),libRmath), Float64, (Float64,Float64,Float64,Int32,Int32), p, p1, p2, lower_tail, log_p)
+            ccall(($(string(qq)),libRmathjulia), Float64, (Float64,Float64,Float64,Int32,Int32), p, p1, p2, lower_tail, log_p)
         $rr(nn::Integer, p1::Number, p2::Number) =
-            [ccall(($(string(rr)),libRmath), Float64, (Float64,Float64), p1, p2) for i=1:nn]
+            [ccall(($(string(rr)),libRmathjulia), Float64, (Float64,Float64), p1, p2) for i=1:nn]
         @libRmath_2par_0d_aliases $base
     end
 end
@@ -396,18 +396,18 @@ end
 @libRmath_deferred_free wilcox
 function dwilcox(x::Number, p1::Number, p2::Number, give_log::Bool)
     wilcox_deferred_free()
-    ccall((:dwilcox,libRmath), Float64, (Float64,Float64,Float64,Int32), x, p1, p2, give_log)
+    ccall((:dwilcox,libRmathjulia), Float64, (Float64,Float64,Float64,Int32), x, p1, p2, give_log)
 end
 function pwilcox(q::Number, p1::Number, p2::Number, lower_tail::Bool, log_p::Bool)
     wilcox_deferred_free()
-    ccall((:pwilcox,libRmath), Float64, (Float64,Float64,Float64,Int32,Int32), q, p1, p2, lower_tail, log_p)
+    ccall((:pwilcox,libRmathjulia), Float64, (Float64,Float64,Float64,Int32,Int32), q, p1, p2, lower_tail, log_p)
 end
 function qwilcox(p::Number, p1::Number, p2::Number, lower_tail::Bool, log_p::Bool)
     wilcox_deferred_free()
-    ccall((:qwilcox,libRmath), Float64, (Float64,Float64,Float64,Int32,Int32), p, p1, p2, lower_tail, log_p)
+    ccall((:qwilcox,libRmathjulia), Float64, (Float64,Float64,Float64,Int32,Int32), p, p1, p2, lower_tail, log_p)
 end
 rwilcox(nn::Integer, p1::Number, p2::Number) =
-    [ccall((:rwilcox,libRmath), Float64, (Float64,Float64), p1, p2) for i=1:nn]
+    [ccall((:rwilcox,libRmathjulia), Float64, (Float64,Float64), p1, p2) for i=1:nn]
 @libRmath_2par_0d_aliases wilcox
 
 ## Distributions with 2 parameters and 1 default
@@ -419,7 +419,7 @@ macro libRmath_2par_1d(base, d2)
     quote
         global $dd, $pp, $qq, $rr
         $dd(x::Number, p1::Number, p2::Number, give_log::Bool) =
-            ccall(($(string(dd)),libRmath), Float64, (Float64,Float64,Float64,Int32), x, p1, p2, give_log)
+            ccall(($(string(dd)),libRmathjulia), Float64, (Float64,Float64,Float64,Int32), x, p1, p2, give_log)
         $dd{T<:Number}(x::AbstractArray{T}, p1::Number, p2::Number, give_log::Bool) =
             reshape([$dd(x[i], p1, p2, give_log) for i=1:length(x)], size(x))
         $dd(x::Number, p1::Number, give_log::Bool) = $dd(x, p1, $d2, give_log)
@@ -430,7 +430,7 @@ macro libRmath_2par_1d(base, d2)
         @vectorize_2arg Number $dd
         
         $pp(q::Number, p1::Number, p2::Number, lower_tail::Bool, log_p::Bool) =
-            ccall(($(string(pp)),libRmath), Float64, (Float64,Float64,Float64,Int32,Int32), q, p1, p2, lower_tail, log_p)
+            ccall(($(string(pp)),libRmathjulia), Float64, (Float64,Float64,Float64,Int32,Int32), q, p1, p2, lower_tail, log_p)
         $pp(q::Number, p1::Number, lower_tail::Bool, log_p::Bool) = $pp(q, p1, $d2, lower_tail, log_p)
         $pp{T<:Number}(q::AbstractArray{T}, p1::Number, p2::Number, lower_tail::Bool, log_p::Bool) =
             reshape([$pp(q[i], p1, p2, lower_tail, log_p) for i=1:length(q)], size(q))
@@ -445,7 +445,7 @@ macro libRmath_2par_1d(base, d2)
         @vectorize_2arg Number $pp
         
         $qq(p::Number, p1::Number, p2::Number, lower_tail::Bool, log_p::Bool) =
-            ccall(($(string(qq)),libRmath), Float64, (Float64,Float64,Float64,Int32,Int32), p, p1, p2, lower_tail, log_p)
+            ccall(($(string(qq)),libRmathjulia), Float64, (Float64,Float64,Float64,Int32,Int32), p, p1, p2, lower_tail, log_p)
         $qq(p::Number, p1::Number, lower_tail::Bool, log_p::Bool) = $qq(p, p1, $d2, lower_tail, log_p)
         $qq{T<:Number}(p::AbstractArray{T}, p1::Number, p2::Number, lower_tail::Bool, log_p::Bool) =
             reshape([$qq(p[i], p1, p2, lower_tail, log_p) for i=1:length(p)], size(p))
@@ -460,7 +460,7 @@ macro libRmath_2par_1d(base, d2)
         @vectorize_2arg Number $qq
 
         $rr(nn::Integer, p1::Number, p2::Number) =
-            [ccall(($(string(rr)),libRmath), Float64, (Float64,Float64), p1, p2) for i=1:nn]
+            [ccall(($(string(rr)),libRmathjulia), Float64, (Float64,Float64), p1, p2) for i=1:nn]
         $rr(nn::Integer, p1::Number) = $rr(nn, p1, $d2)
     end
 end
@@ -482,7 +482,7 @@ macro libRmath_2par_2d(base, d1, d2)
     quote
         global $dd, $pp, $qq, $rr
         $dd(x::Number, p1::Number, p2::Number, give_log::Bool) =
-            ccall(($(string(ddsym)),libRmath), Float64, (Float64,Float64,Float64,Int32), x, p1, p2, give_log)
+            ccall(($(string(ddsym)),libRmathjulia), Float64, (Float64,Float64,Float64,Int32), x, p1, p2, give_log)
         $dd{T<:Number}(x::AbstractArray{T}, p1::Number, p2::Number, give_log::Bool) =
             reshape([$dd(x[i], p1, p2, give_log) for i=1:length(x)], size(x))
         $dd(x::Number, p1::Number, give_log::Bool) = $dd(x, p1, $d2, give_log)
@@ -498,7 +498,7 @@ macro libRmath_2par_2d(base, d1, d2)
 
         
         $pp(q::Number, p1::Number, p2::Number, lower_tail::Bool, log_p::Bool) =
-            ccall(($(string(ppsym)),libRmath), Float64, (Float64,Float64,Float64,Int32,Int32), q, p1, p2, lower_tail, log_p)
+            ccall(($(string(ppsym)),libRmathjulia), Float64, (Float64,Float64,Float64,Int32,Int32), q, p1, p2, lower_tail, log_p)
         $pp{T<:Number}(q::AbstractArray{T}, p1::Number, p2::Number, lower_tail::Bool, log_p::Bool) =
             reshape([$pp(q[i], p1, p2, lower_tail, log_p) for i=1:length(q)], size(q))
         $pp(q::Number, p1::Number, lower_tail::Bool, log_p::Bool) = $pp(q, p1, $d2, lower_tail, log_p)
@@ -519,7 +519,7 @@ macro libRmath_2par_2d(base, d1, d2)
         $pp{T<:Number}(q::AbstractArray{T}) = $pp(q, $d1, $d2, true, false)
         
         $qq(p::Number, p1::Number, p2::Number, lower_tail::Bool, log_p::Bool) =
-            ccall(($(string(qqsym)),libRmath), Float64, (Float64,Float64,Float64,Int32,Int32), p, p1, p2, lower_tail, log_p)
+            ccall(($(string(qqsym)),libRmathjulia), Float64, (Float64,Float64,Float64,Int32,Int32), p, p1, p2, lower_tail, log_p)
         $qq{T<:Number}(p::AbstractArray{T}, p1::Number, p2::Number, lower_tail::Bool, log_p::Bool) =
             reshape([$qq(p[i], p1, p2, lower_tail, log_p) for i=1:length(p)], size(p))
         $qq(p::Number, p1::Number, lower_tail::Bool, log_p::Bool) = $qq(p, p1, $d2, lower_tail, log_p)
@@ -540,7 +540,7 @@ macro libRmath_2par_2d(base, d1, d2)
         $qq{T<:Number}(p::AbstractArray{T}) = $qq(p, $d1, $d2, true, false)
 
         $rr(nn::Integer, p1::Number, p2::Number) =
-            [ccall(($(string(rr)),libRmath), Float64, (Float64,Float64), p1, p2) for i=1:nn]
+            [ccall(($(string(rr)),libRmathjulia), Float64, (Float64,Float64), p1, p2) for i=1:nn]
         $rr(nn::Integer, p1::Number) = $rr(nn, p1, $d2)
         $rr(nn::Integer) = $rr(nn, $d1, $d2)
     end
@@ -561,14 +561,14 @@ macro libRmath_3par_0d(base)
     quote
         global $dd, $pp, $qq, $rr
         $dd(x::Number, p1::Number, p2::Number, p3::Number, give_log::Bool) =
-            ccall(($(string(dd)),libRmath), Float64, (Float64,Float64,Float64,Float64,Int32), x, p1, p2, p3, give_log)
+            ccall(($(string(dd)),libRmathjulia), Float64, (Float64,Float64,Float64,Float64,Int32), x, p1, p2, p3, give_log)
         $dd{T<:Number}(x::AbstractArray{T}, p1::Number, p2::Number, p3::Number, give_log::Bool) =
             reshape([$dd(x[i], p1, p2, p3, give_log) for i=1:length(x)], size(x))
         $dd(x::Number, p1::Number, p2::Number, p3::Number) = $dd(x, p1, p2, p3, false)
         @libRmath_vectorize_4arg $dd
 
         $pp(q::Number, p1::Number, p2::Number, p3::Number, lower_tail::Bool, log_p::Bool) =
-            ccall(($(string(pp)),libRmath), Float64, (Float64,Float64,Float64,Float64,Int32,Int32), q, p1, p2, p3, lower_tail, log_p)
+            ccall(($(string(pp)),libRmathjulia), Float64, (Float64,Float64,Float64,Float64,Int32,Int32), q, p1, p2, p3, lower_tail, log_p)
         $pp{T<:Number}(q::AbstractArray{T}, p1::Number, p2::Number, p3::Number, lower_tail::Bool, log_p::Bool) =
             reshape([$pp(q[i], p1, p2, p3, lower_tail, log_p) for i=1:length(q)], size(q))
         $pp(q::Number, p1::Number, p2::Number, p3::Number, lower_tail::Bool) = $pp(q, p1, p2, p3, lower_tail, false)
@@ -578,7 +578,7 @@ macro libRmath_3par_0d(base)
         @libRmath_vectorize_4arg $pp
 
         $qq(p::Number, p1::Number, p2::Number, p3::Number, lower_tail::Bool, log_p::Bool) =
-            ccall(($(string(qq)),libRmath), Float64, (Float64,Float64,Float64,Float64,Int32,Int32), p, p1, p2, p3, lower_tail, log_p)
+            ccall(($(string(qq)),libRmathjulia), Float64, (Float64,Float64,Float64,Float64,Int32,Int32), p, p1, p2, p3, lower_tail, log_p)
         $qq{T<:Number}(p::AbstractArray{T}, p1::Number, p2::Number, p3::Number, lower_tail::Bool, log_p::Bool) =
             reshape([$qq(p[i], p1, p2, p3, lower_tail, log_p) for i=1:length(p)], size(p))
         $qq(p::Number, p1::Number, p2::Number, p3::Number, lower_tail::Bool) = $qq(p, p1, p2, p3, lower_tail, false)
@@ -588,7 +588,7 @@ macro libRmath_3par_0d(base)
         @libRmath_vectorize_4arg $qq
 
         $rr(nn::Integer, p1::Number, p2::Number, p3::Number) =
-            [ccall(($(string(rr)),libRmath), Float64, (Float64,Float64,Float64), p1, p2, p3) for i=1:nn]
+            [ccall(($(string(rr)),libRmathjulia), Float64, (Float64,Float64,Float64), p1, p2, p3) for i=1:nn]
     end
 end
 
@@ -598,11 +598,11 @@ end
 
 ## tukey (Studentized Range Distribution - p and q only - 3pars)
 ptukey(q::Number, nmeans::Number, df::Number, nranges::Number, lower_tail::Bool, log_p::Bool) =
-    ccall((:ptukey,libRmath), Float64, (Float64,Float64,Float64,Int32,Int32),q,nranges,nmeans,df,lower_tail,log_p)
+    ccall((:ptukey,libRmathjulia), Float64, (Float64,Float64,Float64,Int32,Int32),q,nranges,nmeans,df,lower_tail,log_p)
 ptukey(q::Number, nmeans::Number, df::Number, nranges::Number, lower_tail::Bool) =
-    ccall((:ptukey,libRmath), Float64, (Float64,Float64,Float64,Int32,Int32),q,nranges,nmeans,df,lower_tail,false)
+    ccall((:ptukey,libRmathjulia), Float64, (Float64,Float64,Float64,Int32,Int32),q,nranges,nmeans,df,lower_tail,false)
 ptukey(q::Number, nmeans::Number, df::Number, nranges::Number) =
-    ccall((:ptukey,libRmath), Float64, (Float64,Float64,Float64,Int32,Int32),q,nranges,nmeans,df,true,false)
+    ccall((:ptukey,libRmathjulia), Float64, (Float64,Float64,Float64,Int32,Int32),q,nranges,nmeans,df,true,false)
 ptukey{T<:Number}(q::AbstractArray{T}, nmeans::Number, df::Number, nranges::Number, lower_tail::Bool, log_p::Bool) =
     reshape([ptukey(q[i],nmeans,df,nranges,lower_tail,log_p) for i=1:length(q)], size(q))
 ptukey{T<:Number}(q::AbstractArray{T}, nmeans::Number, df::Number, nranges::Number, lower_tail::Bool) =
@@ -613,13 +613,13 @@ ptukey{T<:Number}(q::AbstractArray{T}, nmeans::Number, df::Number) =
     reshape([ptukey(q[i],nmeans,df,1.,true,false) for i=1:length(q)], size(q))
 
 qtukey(q::Number, nmeans::Number, df::Number, nranges::Number, lower_tail::Bool, log_p::Bool) =
-    ccall((:qtukey,libRmath), Float64, (Float64,Float64,Float64,Int32,Int32),p,nranges,nmeans,df,lower_tail,log_p)
+    ccall((:qtukey,libRmathjulia), Float64, (Float64,Float64,Float64,Int32,Int32),p,nranges,nmeans,df,lower_tail,log_p)
 qtukey(p::Number, nmeans::Number, df::Number, nranges::Number, lower_tail::Bool) =
-    ccall((:qtukey,libRmath), Float64, (Float64,Float64,Float64,Int32,Int32),p,nranges,nmeans,df,lower_tail,false)
+    ccall((:qtukey,libRmathjulia), Float64, (Float64,Float64,Float64,Int32,Int32),p,nranges,nmeans,df,lower_tail,false)
 qtukey(p::Number, nmeans::Number, df::Number, nranges::Number) =
-    ccall((:qtukey,libRmath), Float64, (Float64,Float64,Float64,Int32,Int32),p,nranges,nmeans,df,true,false)
+    ccall((:qtukey,libRmathjulia), Float64, (Float64,Float64,Float64,Int32,Int32),p,nranges,nmeans,df,true,false)
 qtukey(p::Number, nmeans::Number, df::Number) =
-    ccall((:qtukey,libRmath), Float64, (Float64,Float64,Float64,Int32,Int32),p,nranges,1.,df,true,false)
+    ccall((:qtukey,libRmathjulia), Float64, (Float64,Float64,Float64,Int32,Int32),p,nranges,1.,df,true,false)
 qtukey{T<:Number}(p::AbstractArray{T}, nmeans::Number, df::Number, nranges::Number, lower_tail::Bool, log_p::Bool) =
     reshape([qtukey(p[i],nmeans,df,nranges,lower_tail,log_p) for i=1:length(p)], size(p))
 qtukey{T<:Number}(p::AbstractArray{T}, nmeans::Number, df::Number, nranges::Number, lower_tail::Bool) =


### PR DESCRIPTION
Rename the library name from "libRmath" to "libRmathjulia" to avoid using the wrong library from system.
Rename the dependency from "libRmath" to "libRmathdep" to avoid confusing.

This should fix #13. Now Julia v0.4 should be able to set `srand` correctly.
Julia v0.5 still has problem until we build "libRmathjulia" with dSFMT, see another pull request.