### PR TITLE
Bump version of libRmath-julia to 0.2.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.4
-BinDeps
-Compat 0.9.1
+BinDeps 0.6.0
+Compat 0.27.0

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,7 +3,7 @@ using BinDeps, Compat
 @BinDeps.setup
 
 libRmath = library_dependency("libRmathjulia", aliases=["libRmath-julia"])
-version = "0.1"
+version = v"0.2.0"
 # Best practice to use a fixed version here, either a version number tag or a git sha
 # Please don't download "latest master" because the version that works today might not work tomorrow
 
@@ -13,18 +13,23 @@ provides(Sources, URI("https://github.com/JuliaLang/Rmath-julia/archive/v$versio
 prefix = joinpath(BinDeps.depsdir(libRmath), "usr")
 srcdir = joinpath(BinDeps.srcdir(libRmath), "Rmath-julia-$version")
 
-# These Windows binaries were taken from `make -C deps install-Rmath-julia`
-# in a Cygwin cross-compile from the release-0.4 branch of julia
-# Future work: standalone cross-compiled binaries using openSUSE docker container
-provides(Binaries,
-    URI("https://dl.bintray.com/tkelman/generic/libRmath-julia.7z"),
-    [libRmath], unpacked_dir="bin$(Sys.WORD_SIZE)",
-    SHA="d70db19ce7c1aa11015ff9e25e08d068bb80d1237570c9d60ece372712dd3754",
-    os = :Windows)
+if Compat.Sys.iswindows()
+    WIN_SHA = if Sys.ARCH === :x86_64
+        "87e46273e503a9c5b65cf8d920006cb0771d24e38a1c2181e91c84a07cd27f58"
+    else
+        "955bc52329bb9240d71cf31e9eca3ece5ee4bca5d32605de68a6e10d9e91010e"
+    end
+else
+    WIN_SHA = ""
+end
 
-# BSD systems (other than macOS) use BSD Make rather than GNU Make by default
-# We need GNU Make, and on such systems GNU make is invoked as `gmake`
-make = is_bsd() && !is_apple() ? "gmake" : "make"
+# These Windows binaries were built on AppVeyor using Cygwin cross-compile
+provides(Binaries,
+    URI("https://github.com/JuliaLang/Rmath-julia/releases/download/v$version/" *
+        "libRmath-julia-win-$(Sys.ARCH)-v$version.zip"),
+    [libRmath], unpacked_dir="bin$(Sys.WORD_SIZE)",
+    SHA=WIN_SHA,
+    os = :Windows)
 
 # If your library uses configure or cmake, good idea to do an
 # out-of-tree build - see examples in JuliaOpt and JuliaWeb
@@ -34,7 +39,7 @@ provides(SimpleBuild,
         CreateDirectory(joinpath(prefix, "lib"))
         @build_steps begin
             ChangeDirectory(srcdir)
-            `$make USE_DSFMT=1 DSFMT_includedir="$(joinpath(BinDeps.depsdir(libRmath),"dSFMT"))"
+            `$MAKE_CMD USE_DSFMT=1 DSFMT_includedir="$(joinpath(BinDeps.depsdir(libRmath),"dSFMT"))"
                 DSFMT_libdir="$(dirname(Libdl.dlpath("libdSFMT")))"`
             `mv src/libRmath-julia.$(Libdl.dlext) "$prefix/lib"`
         end


### PR DESCRIPTION
Summary of changes:

* Bump BinDeps dependency to 0.6.0 to allow use of the `MAKE_CMD` constant
* Bump Compat to 0.27.0 for 0.7-style OS conditionals
* Bump libRmath-julia to 0.2.0 🆕✨ 
* Use the AppVeyor-built binaries on Windows