### PR TITLE
Error when attempting to build on macOS without Xcode CLT

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,3 +1,8 @@
+if Sys.KERNEL === :Darwin && (!success(`command -v xcode-select`) || isempty(readchomp(`xcode-select -p`)))
+    error("Building Rmath on macOS requires the Xcode command line tools to be installed.\n",
+          "You can install them from the command line using `xcode-select --install`.")
+end
+
 using BinDeps
 
 @BinDeps.setup


### PR DESCRIPTION
Part of https://github.com/JuliaStats/Rmath.jl/issues/27, ref https://github.com/JuliaLang/Rmath-julia/pull/24.

This needs to be taken care of in Rmath.jl rather than in Rmath-julia, since Xcode command line tools includes make, so checking for Xcode CLT from within a Makefile on macOS isn't too useful.