### PR TITLE
Allow Julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.7
   - 1.0
   - 1.2
   - nightly

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 BinaryProvider = "0.3.2, 0.4, 0.5"
-julia = "1"
+julia = "0.7, 1"
 
 [targets]
 test = ["Test"]


### PR DESCRIPTION
To avoid narrowing any of the version ranges during the transition to a project file.